### PR TITLE
Fix POINTTAPI solar detection and zone-name decoding

### DIFF
--- a/custom_components/bosch/pointtapi_entities.py
+++ b/custom_components/bosch/pointtapi_entities.py
@@ -4,6 +4,8 @@ All use CoordinatorEntity; device_info and unique_id follow 2-tuple and entry_id
 """
 from __future__ import annotations
 
+import base64
+import binascii
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -66,6 +68,17 @@ def _val(data: dict[str, Any], path: str, key: str = VALUE_KEY) -> Any:
     """Get key (default 'value') from data[path] if present."""
     obj = data.get(path) if data else None
     return obj.get(key) if isinstance(obj, dict) else None
+
+
+def _decode_zone_name(value: Any) -> str | None:
+    """Decode Bosch zone names, which are returned as base64 UTF-8 strings."""
+    if not isinstance(value, str):
+        return None
+    try:
+        decoded = base64.b64decode(value, validate=True).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return value
+    return decoded
 
 
 def _path_available(data: dict[str, Any], path: str) -> bool:
@@ -378,7 +391,9 @@ class BoschPoinTTAPIClimateEntity(CoordinatorEntity[PoinTTAPIDataUpdateCoordinat
         self._attr_unique_id = f"{entry_id}_pointtapi_{zone_id}"
         # Name zn2+ devices after their room ("/zones/znX/name") when known;
         # zn1 keeps the bare "Heating Zone" name existing installs have.
-        zname = _val(coordinator.data or {}, f"/zones/{zone_id}/name")
+        zname = _decode_zone_name(
+            _val(coordinator.data or {}, f"/zones/{zone_id}/name")
+        )
         suffix = (
             f" {zname}"
             if zone_id != "zn1" and isinstance(zname, str) and zname.strip()

--- a/custom_components/bosch/pointtapi_entities.py
+++ b/custom_components/bosch/pointtapi_entities.py
@@ -49,6 +49,13 @@ _LOGGER = logging.getLogger(__name__)
 
 VALUE_KEY = "value"
 
+SOLAR_CIRCUIT_PATHS = (
+    "/solarCircuits/sc1/collectorTemperature",
+    "/solarCircuits/sc1/dhwTankBottomTemperature",
+    "/solarCircuits/sc1/pumpModulation",
+    "/solarCircuits/sc1/totalSolarGain",
+)
+
 # Water heater operation mode mapping: API value <-> user-friendly label
 # API accepts: "ownprogram" (auto/schedule), "Off", "high" (always on at high temp)
 _API_TO_OP = {"ownprogram": "Auto", "Off": "Off", "high": "On"}
@@ -77,6 +84,20 @@ def _path_available(data: dict[str, Any], path: str) -> bool:
     if not isinstance(obj, dict):
         return False
     return obj.get("available") != "false"
+
+
+def _solar_data_available(data: dict[str, Any]) -> bool:
+    """Return whether the first poll contains at least one usable solar value."""
+    for path in SOLAR_CIRCUIT_PATHS:
+        resource = data.get(path) if data else None
+        if (
+            isinstance(resource, dict)
+            and "value" in resource
+            and resource["value"] is not None
+            and resource.get("available") != "false"
+        ):
+            return True
+    return False
 
 
 # ── Device-info routing: single source of truth for all POINTTAPI entities ──

--- a/custom_components/bosch/sensor/__init__.py
+++ b/custom_components/bosch/sensor/__init__.py
@@ -14,6 +14,7 @@ from ..const import CIRCUITS, CONF_PROTOCOL, DOMAIN, POINTTAPI, SIGNAL_BOSCH, UU
 from ..pointtapi_entities import (
     BoschPoinTTAPISensorEntity,
     _pointtapi_sensor_descriptions,
+    _solar_data_available,
 )
 from ..pointtapi_statistics import async_backfill_gas_history
 from .bosch import BoschSensor
@@ -48,11 +49,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             # Conditional solar: skip the four solar-circuit descriptions if the
             # first coordinator refresh returned no usable /solarCircuits/sc1 data.
             # This stops non-solar households from seeing four ghost entities.
-            solar_data = (coordinator.data or {}).get("/solarCircuits/sc1") or {}
-            solar_has_refs = bool(solar_data.get("references"))
+            solar_available = _solar_data_available(coordinator.data or {})
             descriptions = [
                 desc for desc in _pointtapi_sensor_descriptions()
-                if solar_has_refs or not desc.key.startswith("/solarCircuits")
+                if solar_available or not desc.key.startswith("/solarCircuits")
             ]
             entities = [
                 BoschPoinTTAPISensorEntity(

--- a/unittests/test_pointtapi_entity_robustness.py
+++ b/unittests/test_pointtapi_entity_robustness.py
@@ -37,6 +37,7 @@ from custom_components.bosch.pointtapi_entities import (
     BoschPoinTTAPIWaterHeaterEntity,
     _path_available,
     _pointtapi_sensor_descriptions,
+    _solar_data_available,
 )
 
 
@@ -85,6 +86,49 @@ def _water_heater(coord):
 
 
 OUTDOOR = "/system/sensors/temperatures/outdoor_t1"
+
+
+class TestSolarAvailability:
+    def test_unavailable_solar_resources_are_not_usable(self):
+        data = {
+            "/solarCircuits/sc1": {
+                "references": [
+                    {"id": "/solarCircuits/sc1/collectorTemperature"},
+                ],
+            },
+            "/solarCircuits/sc1/collectorTemperature": {
+                "value": 0.0,
+                "used": "false",
+                "available": "false",
+            },
+            "/solarCircuits/sc1/dhwTankBottomTemperature": {
+                "value": 0.0,
+                "used": "false",
+                "available": "false",
+            },
+            "/solarCircuits/sc1/pumpModulation": {
+                "value": 0.0,
+                "used": "false",
+                "available": "false",
+            },
+            "/solarCircuits/sc1/totalSolarGain": {
+                "value": 0.0,
+                "used": "false",
+                "available": "false",
+            },
+        }
+
+        assert _solar_data_available(data) is False
+
+    def test_zero_is_valid_when_solar_resource_is_available(self):
+        data = {
+            "/solarCircuits/sc1/collectorTemperature": {
+                "value": 0.0,
+                "available": "true",
+            }
+        }
+
+        assert _solar_data_available(data) is True
 
 
 # ── Sensor ──────────────────────────────────────────────────────────────────

--- a/unittests/test_pointtapi_multizone.py
+++ b/unittests/test_pointtapi_multizone.py
@@ -7,7 +7,10 @@ import pytest
 
 from custom_components.bosch.climate import _pointtapi_zone_ids
 from custom_components.bosch.pointtapi_coordinator import _fetch_paths
-from custom_components.bosch.pointtapi_entities import BoschPoinTTAPIClimateEntity
+from custom_components.bosch.pointtapi_entities import (
+    BoschPoinTTAPIClimateEntity,
+    _decode_zone_name,
+)
 
 
 def _coord(data):
@@ -70,6 +73,14 @@ class TestZoneIds:
 
 
 class TestZoneDeviceNaming:
+    def test_decodes_base64_zone_name(self):
+        coord = _coord({"/zones/zn2/name": {"value": "Rmx1ci9aZW50cmFsZQ=="}})
+        ent = BoschPoinTTAPIClimateEntity(coord, "entry1", "uuid1", "zn2")
+        assert ent.device_info["name"] == "Heating Zone Flur/Zentrale"
+
+    def test_keeps_plain_zone_name(self):
+        assert _decode_zone_name("Küche") == "Küche"
+
     def test_zn2_named_after_room(self):
         coord = _coord({"/zones/zn2/name": {"value": "Küche"}})
         ent = BoschPoinTTAPIClimateEntity(coord, "entry1", "uuid1", "zn2")


### PR DESCRIPTION
## Summary

This PR fixes two POINTTAPI issues observed with Bosch EasyControl data:

1. Solar entities were created for installations without solar hardware.
2. Heating zone names were displayed as their base64-encoded API values.

## Changes

### Conditional Solar entities

The API can return the `/solarCircuits/sc1` reference structure even when solar hardware is unavailable. In that case, the solar child resources contain:

- `"used": "false"`
- `"available": "false"`
- `"value": 0.0`

The integration now checks the four solar child resources directly instead of relying only on the presence of root references.

Solar entities are created only when at least one solar resource contains a non-`None` value and is not explicitly marked unavailable.

A valid value of `0.0` is still accepted when the resource reports `"available": "true"`.

This prevents new non-solar installations from receiving ghost Solar entities.

### Zone-name decoding

Bosch returns zone names as base64-encoded UTF-8 strings. For example:

```text
Rmx1ci9aZW50cmFsZQ== -> Flur/Zentrale