### PR TITLE
Fix POINTTAPI child lock switch resolution and thermostat path handling

### DIFF
--- a/custom_components/bosch/pointtapi_entities.py
+++ b/custom_components/bosch/pointtapi_entities.py
@@ -629,13 +629,29 @@ def _thermostat_valve_field(data: dict[str, Any], valve_id: int, field: str) -> 
 
 
 def _thermostat_valve_device_path_from_data(data: dict[str, Any], valve_id: int, suffix: str) -> str | None:
-    """Resolve the valve path from either /devices/list or /devices/deviceX layouts."""
-    candidates = (
-        f"/devices/list/thermostat_valve/{valve_id}/{suffix}",
-        f"/devices/device{valve_id}/{suffix}",
-        f"/devices/device{valve_id}/etrv/{suffix}",
-        f"/devices/device{valve_id}/thermostat/{suffix}",
-    )
+    """Resolve a valve path across list, etrv, thermostat and direct layouts."""
+    suffixes: list[str] = [suffix]
+
+    # Normalize equivalent layouts for thermostat devices (device1 often uses
+    # /thermostat/* instead of /etrv/*).
+    if "/" in suffix:
+        head, tail = suffix.split("/", 1)
+        if head in {"etrv", "thermostat"}:
+            suffixes.extend([tail, f"etrv/{tail}", f"thermostat/{tail}"])
+    else:
+        suffixes.extend([f"etrv/{suffix}", f"thermostat/{suffix}"])
+
+    candidates: list[str] = []
+    for part in dict.fromkeys(suffixes):
+        candidates.extend(
+            [
+                f"/devices/list/thermostat_valve/{valve_id}/{part}",
+                f"/devices/device{valve_id}/{part}",
+                f"/devices/device{valve_id}/etrv/{part}",
+                f"/devices/device{valve_id}/thermostat/{part}",
+            ]
+        )
+
     for path in candidates:
         if path in (data or {}):
             return path
@@ -712,30 +728,56 @@ def _thermostat_valve_device_info(
 def _thermostat_valve_child_lock_path(data: dict[str, Any], valve_id: int) -> str | None:
     """Return the child-lock path exposed for a thermostat valve if any."""
     candidates = (
-        f"/devices/list/thermostat_valve/{valve_id}/childLock",
+        # Use only concrete enabled leaves for switch state semantics.
         f"/devices/list/thermostat_valve/{valve_id}/childLock/enabled",
         f"/devices/list/thermostat_valve/{valve_id}/etrv/childLock/enabled",
-        f"/devices/list/thermostat_valve/{valve_id}/thermostat/childLock",
         f"/devices/list/thermostat_valve/{valve_id}/thermostat/childLock/enabled",
     )
     for path in candidates:
         if path in (data or {}):
             return path
 
-    # Bosch can expose a full device tree under /devices/device{N}/... instead of
-    # the compact /devices/list summary rows. Accept both layouts.
-    device_paths = (
+    # If we got a parent childLock node first, follow its references to the
+    # enabled leaf whenever possible.
+    parent_candidates = (
+        f"/devices/list/thermostat_valve/{valve_id}/childLock",
+        f"/devices/list/thermostat_valve/{valve_id}/etrv/childLock",
+        f"/devices/list/thermostat_valve/{valve_id}/thermostat/childLock",
+        f"/devices/device{valve_id}/childLock",
         f"/devices/device{valve_id}/etrv/childLock",
-        f"/devices/device{valve_id}/etrv/childLock/enabled",
         f"/devices/device{valve_id}/thermostat/childLock",
+    )
+    for parent_path in parent_candidates:
+        parent_obj = (data or {}).get(parent_path)
+        if not isinstance(parent_obj, dict):
+            continue
+        refs = parent_obj.get("references")
+        if not isinstance(refs, list):
+            continue
+        for ref in refs:
+            if not isinstance(ref, dict):
+                continue
+            ref_id = ref.get("id")
+            if (
+                isinstance(ref_id, str)
+                and ref_id.endswith("/enabled")
+                and ref_id in (data or {})
+            ):
+                return ref_id
+
+    # Bosch can expose a full device tree under /devices/device{N}/... instead of
+    # the compact /devices/list summary rows. Accept both layouts, but only
+    # create switch paths on the enabled leaf.
+    device_paths = (
+        f"/devices/device{valve_id}/etrv/childLock/enabled",
         f"/devices/device{valve_id}/thermostat/childLock/enabled",
     )
     for path in device_paths:
         if path in (data or {}):
             return path
 
-    # Some real dumps expose a parent refEnum node with a references list pointing
-    # to the enabled leaf; prefer the leaf path when it exists.
+    # Some real dumps expose a parent refEnum node with a references list
+    # pointing to the enabled leaf; prefer the leaf path when it exists.
     for key, value in (data or {}).items():
         if not isinstance(value, dict):
             continue
@@ -746,22 +788,12 @@ def _thermostat_valve_child_lock_path(data: dict[str, Any], valve_id: int) -> st
                     if not isinstance(ref, dict):
                         continue
                     ref_id = ref.get("id")
-                    if isinstance(ref_id, str) and ref_id.endswith("/enabled"):
+                    if (
+                        isinstance(ref_id, str)
+                        and ref_id.endswith("/enabled")
+                        and ref_id in (data or {})
+                    ):
                         return ref_id
-
-    # When only a summary row is present, look for nested childLock dictionaries.
-    row = _thermostat_valve_row_by_id(data, valve_id)
-    if not isinstance(row, dict):
-        return None
-
-    nested = (
-        row.get("childLock"),
-        (row.get("etrv") or {}).get("childLock"),
-        (row.get("thermostat") or {}).get("childLock"),
-    )
-    for value in nested:
-        if isinstance(value, dict) and ("enabled" in value or "value" in value):
-            return f"/devices/list/thermostat_valve/{valve_id}/childLock"
     return None
 
 
@@ -849,7 +881,11 @@ def _pointtapi_thermostat_valve_sensor_descriptions(
     for key in sorted((data or {}).keys()):
         if not key.startswith("/devices/device"):
             continue
-        if "/etrv/valvePosition" in key:
+        if (
+            "/etrv/valvePosition" in key
+            or "/thermostat/valvePosition" in key
+            or key.endswith("/valvePosition")
+        ):
             valve_id = _thermostat_valve_id_from_path(key)
             if valve_id is None:
                 continue
@@ -867,7 +903,11 @@ def _pointtapi_thermostat_valve_sensor_descriptions(
                     device_info_fn=lambda u, d, lang=None, vid=valve_id: _thermostat_valve_device_info(u, d, vid, lang),
                 )
             )
-        if "/etrv/temperatureActual" in key:
+        if (
+            "/etrv/temperatureActual" in key
+            or "/thermostat/temperatureActual" in key
+            or key.endswith("/temperatureActual")
+        ):
             valve_id = _thermostat_valve_id_from_path(key)
             if valve_id is None:
                 continue
@@ -918,7 +958,6 @@ def _pointtapi_thermostat_valve_switch_descriptions(
             discovered.add(key)
             continue
         if key.endswith("/childLock"):
-            ref_id = None
             obj = (data or {}).get(key)
             if isinstance(obj, dict):
                 refs = obj.get("references")
@@ -929,8 +968,6 @@ def _pointtapi_thermostat_valve_switch_descriptions(
                             if ref_id.endswith("/enabled"):
                                 discovered.add(ref_id)
                                 break
-            if ref_id is None:
-                discovered.add(key)
 
     for path in sorted(discovered):
         valve_id = _thermostat_valve_id_from_path(path)
@@ -2354,7 +2391,13 @@ def _pointtapi_dynamic_number_descriptions(
             discovered.add(path)
 
     for key in sorted((data or {}).keys()):
-        if key.startswith("/devices/device") and key.endswith("/etrv/offset"):
+        if not key.startswith("/devices/device"):
+            continue
+        if (
+            key.endswith("/etrv/offset")
+            or key.endswith("/thermostat/offset")
+            or key.endswith("/offset")
+        ):
             discovered.add(key)
 
     for path in sorted(discovered):
@@ -2403,7 +2446,7 @@ class BoschPoinTTAPINumberEntity(
             data=coordinator.data or {},
         )
         valve_id = _thermostat_valve_id_from_path(description.key)
-        if valve_id is not None and "/etrv/offset" in description.key:
+        if valve_id is not None and description.translation_key == "thermostat_valve_temperature_offset":
             self._attr_device_info = _thermostat_valve_device_info(
                 uuid,
                 coordinator.data or {},
@@ -2885,14 +2928,20 @@ class BoschPoinTTAPIGenericSwitchEntity(
         self._path = description.key
         slug = description.key.strip("/").replace("/", "_")
         self._attr_unique_id = f"{entry_id}_pointtapi_switch_{slug}"
-        # Path-based routing via _resolve_device_info covers /gateway, /dhwCircuits, etc.
-        # device_id_suffix is retained on the description for compatibility but no longer used.
-        self._attr_device_info = _resolve_device_info(
-            uuid,
-            description.key,
-            language=self._language,
-            data=coordinator.data or {},
-        )
+        if description.device_info_fn is not None:
+            self._attr_device_info = description.device_info_fn(
+                uuid, coordinator.data or {}, self._language
+            )
+        else:
+            # Path-based routing via _resolve_device_info covers /gateway,
+            # /dhwCircuits, etc. device_id_suffix is retained on the
+            # description for compatibility but no longer used.
+            self._attr_device_info = _resolve_device_info(
+                uuid,
+                description.key,
+                language=self._language,
+                data=coordinator.data or {},
+            )
         self._is_on: bool = False
 
     @callback

--- a/custom_components/bosch/pointtapi_entities.py
+++ b/custom_components/bosch/pointtapi_entities.py
@@ -630,27 +630,18 @@ def _thermostat_valve_field(data: dict[str, Any], valve_id: int, field: str) -> 
 
 def _thermostat_valve_device_path_from_data(data: dict[str, Any], valve_id: int, suffix: str) -> str | None:
     """Resolve a valve path across list, etrv, thermostat and direct layouts."""
-    suffixes: list[str] = [suffix]
-
-    # Normalize equivalent layouts for thermostat devices (device1 often uses
-    # /thermostat/* instead of /etrv/*).
+    leaf = suffix
     if "/" in suffix:
         head, tail = suffix.split("/", 1)
         if head in {"etrv", "thermostat"}:
-            suffixes.extend([tail, f"etrv/{tail}", f"thermostat/{tail}"])
-    else:
-        suffixes.extend([f"etrv/{suffix}", f"thermostat/{suffix}"])
+            leaf = tail
 
-    candidates: list[str] = []
-    for part in dict.fromkeys(suffixes):
-        candidates.extend(
-            [
-                f"/devices/list/thermostat_valve/{valve_id}/{part}",
-                f"/devices/device{valve_id}/{part}",
-                f"/devices/device{valve_id}/etrv/{part}",
-                f"/devices/device{valve_id}/thermostat/{part}",
-            ]
-        )
+    candidates: list[str] = [
+        f"/devices/list/thermostat_valve/{valve_id}/{leaf}",
+        f"/devices/device{valve_id}/{leaf}",
+        f"/devices/device{valve_id}/etrv/{leaf}",
+        f"/devices/device{valve_id}/thermostat/{leaf}",
+    ]
 
     for path in candidates:
         if path in (data or {}):

--- a/unittests/test_pointtapi_entity_coverage.py
+++ b/unittests/test_pointtapi_entity_coverage.py
@@ -177,7 +177,7 @@ class TestThermostatValveHelpers:
         nested = {
             "/devices/list": {"value": [{"id": 7, "type": "thermostat_valve", "childLock": {"enabled": True}}]}
         }
-        assert _thermostat_valve_child_lock_path(nested, 7).endswith("/childLock")
+        assert _thermostat_valve_child_lock_path(nested, 7) is None
         assert _thermostat_valve_device_path_from_data({}, 7, "etrv/name") is None
         assert _thermostat_valve_battery(nested, 99) is None
         assert _thermostat_valve_zone_name(nested, 7) is None
@@ -186,7 +186,8 @@ class TestThermostatValveHelpers:
         referenced = {
             "/devices/device7/etrv/childLock/refEnum": {
                 "references": [{"id": "/devices/device7/etrv/childLock/enabled"}]
-            }
+            },
+            "/devices/device7/etrv/childLock/enabled": {"value": True},
         }
         assert _thermostat_valve_child_lock_path(referenced, 7).endswith("/enabled")
 

--- a/unittests/test_pointtapi_entity_coverage.py
+++ b/unittests/test_pointtapi_entity_coverage.py
@@ -187,7 +187,14 @@ class TestThermostatValveHelpers:
             "/devices/device7/etrv/childLock/refEnum": {
                 "references": [{"id": "/devices/device7/etrv/childLock/enabled"}]
             },
-            "/devices/device7/etrv/childLock/enabled": {"value": True},
+            "/devices/device7/etrv/childLock/enabled": {
+                "type": "stringValue",
+                "writeable": 1,
+                "used": "true",
+                "recordable": 0,
+                "available": "true",
+                "value": "true",
+            },
         }
         assert _thermostat_valve_child_lock_path(referenced, 7).endswith("/enabled")
 

--- a/unittests/test_pointtapi_entity_coverage.py
+++ b/unittests/test_pointtapi_entity_coverage.py
@@ -198,6 +198,81 @@ class TestThermostatValveHelpers:
         }
         assert _thermostat_valve_child_lock_path(referenced, 7).endswith("/enabled")
 
+    @pytest.mark.parametrize(
+        "data, valve_id, suffix, expected",
+        [
+            # Case 1: list summary layout
+            (
+                {"/devices/list/thermostat_valve/2/temperatureActual": {"value": 21.0}},
+                2,
+                "etrv/temperatureActual",
+                "/devices/list/thermostat_valve/2/temperatureActual",
+            ),
+            (
+                {"/devices/list/thermostat_valve/2/temperatureActual": {"value": 21.0}},
+                2,
+                "temperatureActual",
+                "/devices/list/thermostat_valve/2/temperatureActual",
+            ),
+            # Case 2: direct device layout
+            (
+                {"/devices/device2/temperatureActual": {"value": 21.0}},
+                2,
+                "etrv/temperatureActual",
+                "/devices/device2/temperatureActual",
+            ),
+            # Case 3: eTRV device layout (real dump devices 2-13)
+            (
+                {
+                    "/devices/device2/etrv/temperatureActual": {"value": 22.9},
+                    "/devices/device2/etrv/valvePosition": {"value": 0.0},
+                    "/devices/device2/etrv/offset": {"value": 0.0},
+                },
+                2,
+                "etrv/temperatureActual",
+                "/devices/device2/etrv/temperatureActual",
+            ),
+            (
+                {"/devices/device2/etrv/offset": {"value": 0.0}},
+                2,
+                "etrv/offset",
+                "/devices/device2/etrv/offset",
+            ),
+            # Case 4: thermostat device layout (real dump device 1)
+            (
+                {"/devices/device1/thermostat/temperatureActual": {"value": 24.4}},
+                1,
+                "thermostat/temperatureActual",
+                "/devices/device1/thermostat/temperatureActual",
+            ),
+            (
+                {"/devices/device1/thermostat/offset": {"value": 0.0}},
+                1,
+                "etrv/offset",
+                "/devices/device1/thermostat/offset",
+            ),
+            # Case 5: candidate resolution priority (list > direct device > etrv > thermostat)
+            (
+                {
+                    "/devices/list/thermostat_valve/2/offset": {"value": 0.0},
+                    "/devices/device2/etrv/offset": {"value": 0.0},
+                },
+                2,
+                "etrv/offset",
+                "/devices/list/thermostat_valve/2/offset",
+            ),
+            # Case 6: no match returns None
+            (
+                {},
+                2,
+                "etrv/temperatureActual",
+                None,
+            ),
+        ],
+    )
+    def test_thermostat_valve_device_path_from_data_all_layouts(self, data, valve_id, suffix, expected):
+        assert _thermostat_valve_device_path_from_data(data, valve_id, suffix) == expected
+
     @pytest.mark.parametrize("warning, expected", [(0, False), (1, True), ("bad", True), (None, None)])
     def test_valve_warning_state(self, warning, expected):
         data = {"/devices/list": {"value": [{"id": 7, "type": "thermostat_valve", "warning": warning}]}}

--- a/unittests/test_pointtapi_new_entities.py
+++ b/unittests/test_pointtapi_new_entities.py
@@ -155,12 +155,38 @@ class TestNotificationsHelpers:
         }
 
         switch_descs = _pointtapi_thermostat_valve_switch_descriptions(data)
+        assert switch_descs == ()
 
+    def test_thermostat_valve_child_lock_prefers_enabled_leaf_from_parent_reference(self):
+        data = {
+            "/devices/list": {
+                "value": [
+                    {
+                        "id": 7,
+                        "type": "thermostat_valve",
+                        "name": "Valve 7",
+                    }
+                ]
+            },
+            "/devices/list/thermostat_valve/7/childLock": {
+                "id": "/devices/list/thermostat_valve/7/childLock",
+                "type": "refEnum",
+                "references": [
+                    {"id": "/devices/list/thermostat_valve/7/childLock/enabled"}
+                ],
+            },
+            "/devices/list/thermostat_valve/7/childLock/enabled": {
+                "id": "/devices/list/thermostat_valve/7/childLock/enabled",
+                "type": "boolValue",
+                "value": True,
+                "writeable": 1,
+            },
+        }
+
+        switch_descs = _pointtapi_thermostat_valve_switch_descriptions(data)
         assert [desc.key for desc in switch_descs] == [
-            "/devices/list/thermostat_valve/7/childLock"
+            "/devices/list/thermostat_valve/7/childLock/enabled"
         ]
-        assert switch_descs[0].translation_key == "thermostat_valve_child_lock"
-        assert switch_descs[0].device_info_fn is not None
 
     def test_thermostat_valve_child_lock_switch_discovery_from_full_device_tree(self):
         data = {
@@ -292,6 +318,104 @@ class TestNotificationsHelpers:
         temp_desc = next(desc for desc in sensor_descs if desc.key == "/devices/device2/etrv/temperatureActual")
         assert temp_desc.translation_key == "thermostat_valve_temperature_actual"
         assert temp_desc.native_unit_of_measurement == "°C"
+
+    def test_thermostat_device_paths_without_etrv_are_discovered(self):
+        data = {
+            "/devices/device1": {
+                "id": "/devices/device1",
+                "type": "refEnum",
+                "references": [
+                    {"id": "/devices/device1/thermostat"},
+                    {"id": "/devices/device1/type"},
+                ],
+            },
+            "/devices/device1/thermostat": {
+                "id": "/devices/device1/thermostat",
+                "type": "refEnum",
+                "references": [
+                    {"id": "/devices/device1/thermostat/valvePosition"},
+                    {"id": "/devices/device1/thermostat/temperatureActual"},
+                    {"id": "/devices/device1/thermostat/offset"},
+                ],
+            },
+            "/devices/device1/thermostat/valvePosition": {
+                "id": "/devices/device1/thermostat/valvePosition",
+                "type": "floatValue",
+                "value": 39.0,
+                "unitOfMeasure": "%",
+            },
+            "/devices/device1/thermostat/temperatureActual": {
+                "id": "/devices/device1/thermostat/temperatureActual",
+                "type": "floatValue",
+                "value": 20.5,
+                "unitOfMeasure": "°C",
+            },
+            "/devices/device1/thermostat/offset": {
+                "id": "/devices/device1/thermostat/offset",
+                "type": "floatValue",
+                "value": 0.0,
+                "minValue": -2.0,
+                "maxValue": 2.0,
+                "stepSize": 0.5,
+                "unitOfMeasure": "C",
+            },
+            "/devices/device1/type": {
+                "id": "/devices/device1/type",
+                "type": "stringValue",
+                "value": "thermostat",
+            },
+        }
+
+        sensor_descs = {d.key: d for d in _pointtapi_thermostat_valve_sensor_descriptions(data)}
+        assert "/devices/device1/thermostat/valvePosition" in sensor_descs
+        assert "/devices/device1/thermostat/temperatureActual" in sensor_descs
+
+        number_descs = {d.key: d for d in _pointtapi_number_descriptions(data)}
+        assert "/devices/device1/thermostat/offset" in number_descs
+        assert number_descs["/devices/device1/thermostat/offset"].translation_key == "thermostat_valve_temperature_offset"
+
+    def test_thermostat_device_child_lock_uses_enabled_leaf(self):
+        data = {
+            "/devices/device1": {
+                "id": "/devices/device1",
+                "type": "refEnum",
+                "references": [
+                    {"id": "/devices/device1/thermostat"},
+                    {"id": "/devices/device1/type"},
+                ],
+            },
+            "/devices/device1/thermostat": {
+                "id": "/devices/device1/thermostat",
+                "type": "refEnum",
+                "references": [
+                    {"id": "/devices/device1/thermostat/childLock"},
+                ],
+            },
+            "/devices/device1/thermostat/childLock": {
+                "id": "/devices/device1/thermostat/childLock",
+                "type": "refEnum",
+                "references": [
+                    {"id": "/devices/device1/thermostat/childLock/enabled"},
+                ],
+            },
+            "/devices/device1/thermostat/childLock/enabled": {
+                "id": "/devices/device1/thermostat/childLock/enabled",
+                "type": "boolValue",
+                "value": False,
+                "writeable": 1,
+            },
+            "/devices/device1/type": {
+                "id": "/devices/device1/type",
+                "type": "stringValue",
+                "value": "thermostat",
+            },
+        }
+
+        switch_descs = _pointtapi_thermostat_valve_switch_descriptions(data)
+        assert any(
+            desc.key == "/devices/device1/thermostat/childLock/enabled"
+            for desc in switch_descs
+        )
 
     def test_real_dump_like_fragment_exercises_etrv_and_zone_paths(self):
         data = {
@@ -743,6 +867,42 @@ class TestComfortControlDescriptions:
         assert desc.native_min_value == -6.0
         assert desc.native_max_value == 6.0
         assert desc.native_step == 0.5
+        assert desc.entity_category == EntityCategory.CONFIG
+
+    def test_thermostat_temperature_offset_is_described_from_device_tree(self):
+        data = {
+            "/devices/device1": {
+                "id": "/devices/device1",
+                "type": "refEnum",
+                "references": [{"id": "/devices/device1/thermostat"}],
+            },
+            "/devices/device1/thermostat": {
+                "id": "/devices/device1/thermostat",
+                "type": "refEnum",
+                "references": [{"id": "/devices/device1/thermostat/offset"}],
+            },
+            "/devices/device1/thermostat/offset": {
+                "id": "/devices/device1/thermostat/offset",
+                "type": "floatValue",
+                "value": 0.25,
+                "minValue": -3.0,
+                "maxValue": 3.0,
+                "stepSize": 0.25,
+                "unitOfMeasure": "C",
+            },
+            "/devices/device1/type": {
+                "id": "/devices/device1/type",
+                "type": "stringValue",
+                "value": "thermostat",
+            },
+        }
+
+        descs = {d.key: d for d in _pointtapi_number_descriptions(data)}
+        desc = descs["/devices/device1/thermostat/offset"]
+        assert desc.translation_key == "thermostat_valve_temperature_offset"
+        assert desc.native_min_value == -3.0
+        assert desc.native_max_value == 3.0
+        assert desc.native_step == 0.25
         assert desc.entity_category == EntityCategory.CONFIG
 
     def test_thermal_disinfect_weekday_options(self):

--- a/unittests/test_pointtapi_new_entities.py
+++ b/unittests/test_pointtapi_new_entities.py
@@ -177,9 +177,12 @@ class TestNotificationsHelpers:
             },
             "/devices/list/thermostat_valve/7/childLock/enabled": {
                 "id": "/devices/list/thermostat_valve/7/childLock/enabled",
-                "type": "boolValue",
-                "value": True,
+                "type": "stringValue",
                 "writeable": 1,
+                "used": "true",
+                "recordable": 0,
+                "available": "true",
+                "value": "true",
             },
         }
 
@@ -213,9 +216,12 @@ class TestNotificationsHelpers:
             },
             "/devices/device7/etrv/childLock/enabled": {
                 "id": "/devices/device7/etrv/childLock/enabled",
-                "type": "boolValue",
-                "value": True,
+                "type": "stringValue",
                 "writeable": 1,
+                "used": "true",
+                "recordable": 0,
+                "available": "true",
+                "value": "true",
             },
             "/devices/device7/type": {
                 "id": "/devices/device7/type",
@@ -400,9 +406,12 @@ class TestNotificationsHelpers:
             },
             "/devices/device1/thermostat/childLock/enabled": {
                 "id": "/devices/device1/thermostat/childLock/enabled",
-                "type": "boolValue",
-                "value": False,
+                "type": "stringValue",
                 "writeable": 1,
+                "used": "true",
+                "recordable": 0,
+                "available": "true",
+                "value": "false",
             },
             "/devices/device1/type": {
                 "id": "/devices/device1/type",
@@ -416,6 +425,23 @@ class TestNotificationsHelpers:
             desc.key == "/devices/device1/thermostat/childLock/enabled"
             for desc in switch_descs
         )
+
+        desc = next(
+            d
+            for d in switch_descs
+            if d.key == "/devices/device1/thermostat/childLock/enabled"
+        )
+        coordinator = MagicMock(data=data)
+        entity = BoschPoinTTAPIGenericSwitchEntity(
+            coordinator,
+            "entry-1",
+            "uuid-1",
+            desc,
+        )
+        entity.hass = MagicMock()
+        entity.async_write_ha_state = MagicMock()
+        entity._handle_coordinator_update()
+        assert entity.is_on is False
 
     def test_real_dump_like_fragment_exercises_etrv_and_zone_paths(self):
         data = {
@@ -450,9 +476,12 @@ class TestNotificationsHelpers:
             },
             "/devices/device2/etrv/childLock/enabled": {
                 "id": "/devices/device2/etrv/childLock/enabled",
-                "type": "boolValue",
-                "value": True,
+                "type": "stringValue",
                 "writeable": 1,
+                "used": "true",
+                "recordable": 0,
+                "available": "true",
+                "value": "true",
             },
             "/devices/device2/etrv/valvePosition": {
                 "id": "/devices/device2/etrv/valvePosition",

--- a/unittests/test_pointtapi_setup.py
+++ b/unittests/test_pointtapi_setup.py
@@ -59,9 +59,6 @@ async def test_pointtapi_refreshes_before_forwarding_platforms():
         def __init__(self, *_):
             pass
 
-        async def async_load_persistent_cache(self):
-            events.append("cache")
-
         async def async_config_entry_first_refresh(self):
             events.append("refresh")
 
@@ -90,9 +87,6 @@ async def test_pointtapi_refresh_failure_does_not_forward_platforms():
 
     class Coordinator:
         def __init__(self, *_):
-            pass
-
-        async def async_load_persistent_cache(self):
             pass
 
         async def async_config_entry_first_refresh(self):


### PR DESCRIPTION
## Summary
This PR fixes multiple POINTTAPI thermostat-valve issues found during live testing and dump validation.

## What is fixed
- Fixes child-lock switch device attachment:
  - dynamic thermostat-valve child-lock switches now attach to the dedicated thermostat-valve device, not the gateway fallback.
- Adds support for thermostat-style device paths:
  - handles `/devices/deviceN/thermostat/*` alongside existing `etrv` paths for valve-related entities.
- Makes child-lock switch discovery strict and consistent:
  - a switch is created only when a concrete `.../childLock/enabled` leaf is available in coordinator data.
  - no parent `.../childLock` fallback switch is exposed.
- Strengthens discovery behavior for mixed layouts:
  - supports both direct device-tree paths and reference-following to enabled leaf nodes.

## Why this is needed
- Real-world dumps show different path layouts by device type:
  - `device1` can expose thermostat paths (`/thermostat/...`),
  - other valves can expose `etrv` paths.
- Child-lock state/write semantics should mirror existing enabled-leaf switches (like `/gateway/notificationLight/enabled`) to avoid ambiguous parent-node behavior.
- Without these fixes, users can see wrong device grouping in HA and/or missing or incorrect child-lock switches.

## Validation
- Updated and added unit tests for:
  - enabled-leaf child-lock discovery,
  - thermostat-path variants,
  - strict no-switch behavior when no concrete enabled path is available.
- Test results:
  - `unittests/test_pointtapi_new_entities.py`: passing
  - `unittests/test_pointtapi_entity_coverage.py`: passing
